### PR TITLE
Image bg css fix

### DIFF
--- a/packages/plugins/layout/background/src/index.css
+++ b/packages/plugins/layout/background/src/index.css
@@ -26,6 +26,7 @@
   background-size: cover;
   color: white;
   padding: 12px;
+  position: relative;
 }
 
 .ory-plugins-layout-background__backstretch {


### PR DESCRIPTION
This was causing the backstretch to span whole container. 

Signed-off-by: Peter Kottas <petokottas@gmail.com>