### PR TITLE
Bugfixes in html5video

### DIFF
--- a/packages/plugins/content/html5-video/src/Component/index.js
+++ b/packages/plugins/content/html5-video/src/Component/index.js
@@ -29,8 +29,8 @@ import { darkTheme } from 'ory-editor-ui/lib/ThemeProvider'
 
 export type Props = ContentPluginProps<*>
 
-const changeUrl = (onChange: any) => (event: Event, newValue: string) =>
-  onChange({ url: newValue })
+const changeUrl = (onChange: any) => (event: Event) =>
+  event.target && onChange({ url: event.target.value })
 
 const HTML5Video = ({
   readOnly,

--- a/packages/plugins/content/html5-video/src/Component/index.js
+++ b/packages/plugins/content/html5-video/src/Component/index.js
@@ -51,6 +51,7 @@ const HTML5Video = ({
           label="Video url"
           onChange={changeUrl(onChange)}
           value={url}
+          style={{ width: '512px' }}
         />
       </BottomToolbar>
     ) : null}

--- a/packages/plugins/content/html5-video/src/Component/index.js
+++ b/packages/plugins/content/html5-video/src/Component/index.js
@@ -54,7 +54,7 @@ const HTML5Video = ({
         />
       </BottomToolbar>
     ) : null}
-    <video autoPlay controls loop muted width="100%">
+    <video autoPlay controls loop muted width="100%" key={url}>
       <source src={url} type={`video/${url.split('.').pop()}`} />
     </video>
   </div>


### PR DESCRIPTION
A few things were broken:
1. the `<TextField>` wasn't changing its value
2. the width was very small (I changed to be the same as in the other `video` plugin)
3. when the value was changed, the html element wasn't updated accordingly (needed a page refresh to show the new content)