### PR TITLE
Bump video package version to 1.8.0 to fix SSR

### DIFF
--- a/packages/plugins/content/video/package-lock.json
+++ b/packages/plugins/content/video/package-lock.json
@@ -42,9 +42,9 @@
 			}
 		},
 		"react-player": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/react-player/-/react-player-1.7.1.tgz",
-			"integrity": "sha512-arBhAfKPdTOME47qAsk7g8MWIZXP/5TaqV0kRfUr2cDuUgqTTvlFRL7mgC4++a74fxMqUcqNOQL+ClpdH3skpA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/react-player/-/react-player-1.8.0.tgz",
+			"integrity": "sha512-DqIJvkL7itGLgs/8u+sgeD3DXq5kc/O6FsB6J9KEuoaiYiSKhluBRymZWIwfCuPNTdpPsA2roZ+NSCyLrHAA9g==",
 			"requires": {
 				"deepmerge": "2.2.1",
 				"load-script": "1.0.0",

--- a/packages/plugins/content/video/package.json
+++ b/packages/plugins/content/video/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ory-editor-core": "0.0.0",
     "ory-editor-ui": "0.0.0",
-    "react-player": "1.7.1"
+    "react-player": "1.8.0"
   },
   "devDependencies": {},
   "publishConfig": {


### PR DESCRIPTION
version 1.7.1 of react-player introduced a SSR bug by referencing navigator in global scope without checking whether it was undefined first. This was fixed by 1.8.0. Fixes #637