### PR TITLE
Remove !important from inline style as unsupported

### DIFF
--- a/packages/plugins/content/video/src/Renderer/VideoHtmlRenderer.tsx
+++ b/packages/plugins/content/video/src/Renderer/VideoHtmlRenderer.tsx
@@ -47,8 +47,8 @@ const Display: React.SFC<VideoHtmlRendererProps> = ({ state: { src }, readOnly }
         width="100%"
         style={{
           position: 'absolute',
-          width: '100% !important',
-          height: '100% !important',
+          width: '100%',
+          height: '100%',
         }}
       />
     </div>


### PR DESCRIPTION
https://github.com/facebook/react/issues/1881

The video plugin doesn't fill the container currently