### PR TITLE
Check if node exists on focusNext and focusPrev

### DIFF
--- a/packages/core/src/components/HotKey/Decorator.tsx
+++ b/packages/core/src/components/HotKey/Decorator.tsx
@@ -129,7 +129,11 @@ class Decorator extends Component {
         return;
       }
 
-      const { node: n } = this.props.searchNodeEverywhere(this.props.focus);
+      const maybeNode = this.props.searchNodeEverywhere(this.props.focus);
+      if (!maybeNode) {
+        return;
+      }
+      const { node: n } = maybeNode;
       hotKeyHandler(n, 'handleFocusNextHotKey')(e, n)
         .then(() => {
           const found = nextLeaf(
@@ -150,7 +154,11 @@ class Decorator extends Component {
         return;
       }
 
-      const { node: n } = this.props.searchNodeEverywhere(this.props.focus);
+      const maybeNode = this.props.searchNodeEverywhere(this.props.focus);
+      if (!maybeNode) {
+        return;
+      }
+      const { node: n } = maybeNode;
       hotKeyHandler(n, 'handleFocusPreviousHotKey')(e, n)
         .then(() => {
           const found = previousLeaf(


### PR DESCRIPTION
#583 fixed #579 but I'm still receiving those errors on sentry sometimes:
`null is not an object (evaluating 't.props.searchNodeEverywhere(t.props.focus)`
`Cannot read property 'node' of null`

I've seen that they are coming from the focusNext function, I'm simply applying the same fix that was applied to the remove function to the focusNext and focusPrev function.