### PR TITLE
Fixing wrong state management in video plugin

### DIFF
--- a/packages/plugins/content/video/src/Component/index.tsx
+++ b/packages/plugins/content/video/src/Component/index.tsx
@@ -57,8 +57,9 @@ class Video extends React.PureComponent<VideoProps, VideoState> {
   }
 
   private commitSrc() {
+    const src = this.state.src;
     this.setState({ src: undefined }, () =>
-      this.props.onChange({ src: this.state.src })
+      this.props.onChange({ src })
     );
   }
 }

--- a/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
+++ b/packages/plugins/content/video/src/Controls/VideoDefaultControls.tsx
@@ -42,7 +42,7 @@ const Form: React.SFC<VideoControlsProps> = props => {
   return (
     <div>
       <Renderer {...props} />
-      {!readOnly && focused && (
+      {!readOnly && (
         <BottomToolbar open={focused} theme={darkTheme}>
           <TextField
             placeholder={placeholder}


### PR DESCRIPTION
Problems fixed:
- Clicking outside of the `BottomToolbar` now calls the `TextField.onBlur` event. It was not calling because of the `focused` prop, it was unmounting the `BottomToolbar` component, therefor not calling `TextField.onBlur`;
- Save the `this.state.src` in a variable to send it in `this.props.onChange`. It was sending always `undefined`.